### PR TITLE
Update UI to fit new default look

### DIFF
--- a/styles/editor-stats.less
+++ b/styles/editor-stats.less
@@ -25,6 +25,8 @@
     font-size: 10px;
     fill: rgba(255, 255, 255, 0.2);
     font-family: Courier;
+    -webkit-user-select: none;
+    cursor: default;
   }
 
   .minor text {

--- a/styles/editor-stats.less
+++ b/styles/editor-stats.less
@@ -1,17 +1,16 @@
 .editor-stats-wrapper {
   padding: 5px;
   box-sizing: border-box;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .editor-stats {
   height: 50px;
   width: 100%;
   background: #1d1f21;
-  border: 1px solid rgba(0, 0, 0, 0.3);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
   overflow: hidden;
+  background: #1a2226;
+  border: 1px solid #171e22;
+  border-radius: 3px;
 
   .bar {
     fill: rgba(255, 255, 255, 0.2);

--- a/styles/editor-stats.less
+++ b/styles/editor-stats.less
@@ -11,6 +11,7 @@
   border: 1px solid rgba(0, 0, 0, 0.3);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   border-right: 1px solid rgba(255, 255, 255, 0.1);
+  overflow: hidden;
 
   .bar {
     fill: rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
This package hasn't been updated for years, so the UI really lags behind the new default look of Atom. This pull request changes that by ...

- removing all of the "shading" (light and dark borders)
- making the colors fit the new look (blueish instead of brownish)
- preventing the users from selecting the time labels
- hiding the overflowing time labels

**Before/after:**
![Before/after](https://user-images.githubusercontent.com/29176678/28812916-4644dca6-7697-11e7-8711-fdb895ce3220.png)
*I feel like the bars should be moved one or two pixels down, but I didn't want to break any of the CoffeScript.*